### PR TITLE
Add ability to render custom Grommet marker

### DIFF
--- a/src/GrommetMarker.jsx
+++ b/src/GrommetMarker.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import {
+  createElementObject,
+  createPathComponent,
+  extendContext,
+} from '@react-leaflet/core';
+import L from 'leaflet';
+import { Location } from 'grommet-icons';
+
+const createGrommetMarker = (
+  { position, title, alt, icon: iconProp },
+  context,
+) => {
+  const icon = L.divIcon({
+    // 'grommet-marker' class prevents leaflet default divIcon styles
+    className: 'grommet-marker',
+    html: ReactDOMServer.renderToString(iconProp || <Location />),
+  });
+  const options = { title, alt, icon };
+  const marker = new L.Marker(position, options);
+  return createElementObject(
+    marker,
+    extendContext(context, { overlayContainer: marker }),
+  );
+};
+
+const updateGrommetMarker = (instance, props, prevProps) => {
+  if (props.position !== prevProps.position) {
+    instance.setLatLng(props.position);
+  }
+};
+
+const GrommetMarker = createPathComponent(
+  createGrommetMarker,
+  updateGrommetMarker,
+);
+
+export default GrommetMarker;

--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { MapContainer, TileLayer } from "react-leaflet";
-import { Box } from "grommet";
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { MapContainer, Marker, TileLayer } from 'react-leaflet';
+import { Box } from 'grommet';
 
 function Map() {
   const [geolocation, setGeolocation] = useState();
@@ -8,13 +8,14 @@ function Map() {
   const mapContainerRef = useRef();
 
   const adjustSize = () => {
-    const map = document.getElementById("map");
+    const map = document.getElementById('map');
     if (containerRef.current && map) {
       const height = containerRef.current.getBoundingClientRect().height;
       map.style.height = `${height}px`;
     }
   };
 
+  // get the user's location
   useEffect(() => {
     navigator.geolocation.getCurrentPosition(
       (position) => {
@@ -23,18 +24,19 @@ function Map() {
           position.coords.longitude,
         ];
         setGeolocation(nextLocation);
-        localStorage.setItem("geolocation", JSON.stringify(nextLocation));
+        localStorage.setItem('geolocation', JSON.stringify(nextLocation));
       },
       () => {
-        const stored = localStorage.getItem("geolocation");
+        const stored = localStorage.getItem('geolocation');
         if (stored) setGeolocation(JSON.parse(stored));
-      }
+      },
     );
   }, []);
 
+  // adjust the map size when the window is resized
   useEffect(() => {
-    window.addEventListener("resize", adjustSize);
-    return () => window.removeEventListener("resize", adjustSize);
+    window.addEventListener('resize', adjustSize);
+    return () => window.removeEventListener('resize', adjustSize);
   });
 
   useLayoutEffect(adjustSize);
@@ -49,14 +51,14 @@ function Map() {
           zoom={6}
           scrollWheelZoom={false}
         >
-          {/* <TileLayer
-            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          /> */}
           <TileLayer
-            attribution='&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+            attribution={`
+              &copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, 
+              &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> 
+              &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors`}
             url="https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png"
           />
+          <Marker position={geolocation} />
         </MapContainer>
       )}
     </Box>

--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { MapContainer, Marker, TileLayer } from 'react-leaflet';
+import { MapContainer, TileLayer } from 'react-leaflet';
 import { Box } from 'grommet';
+import { Grommet } from 'grommet-icons';
+
+import GrommetMarker from './GrommetMarker';
 
 function Map() {
   const [geolocation, setGeolocation] = useState();
@@ -58,7 +61,7 @@ function Map() {
               &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors`}
             url="https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png"
           />
-          <Marker position={geolocation} />
+          <GrommetMarker position={geolocation} icon={<Grommet />} />
         </MapContainer>
       )}
     </Box>


### PR DESCRIPTION
Allows caller to use Grommet icons or other React components as a leaflet Marker.