### PR TITLE
Fix rotation of status icons

### DIFF
--- a/grommet-leaflet-core/src/markers/Pin.jsx
+++ b/grommet-leaflet-core/src/markers/Pin.jsx
@@ -47,11 +47,7 @@ const Pin = ({ status }) => {
         <StatusIcon
           color={STATUS_MAP[status].color}
           size="13px"
-          style={
-            status === 'warning' || status === 'unknown'
-              ? { transform: 'rotate(-45deg)' }
-              : undefined
-          }
+          style={{ transform: 'rotate(-45deg)' }}
         />
       </StyledBox>
     </Grommet>


### PR DESCRIPTION
All status icons should be rotated 45deg to offset the 45deg rotation of the box.

This fixes "critical" icon which is currently rendering as a square as opposed to diamond.