### PR TITLE
Remove polygon on cluster hover

### DIFF
--- a/grommet-leaflet-core/src/layers/MarkerCluster.jsx
+++ b/grommet-leaflet-core/src/layers/MarkerCluster.jsx
@@ -17,6 +17,7 @@ const createMarkerClusterGroup = (
   const theme = React.useContext(ThemeContext);
 
   const markerClusterGroup = new L.MarkerClusterGroup({
+    showCoverageOnHover: false,
     zoomToBoundsOnClick: false,
     iconCreateFunction: cluster => {
       if (popupProp) {


### PR DESCRIPTION
Removes polygon on hover of cluster by default:

https://github.com/grommet/grommet-leaflet/assets/12522275/c0ba3596-a24b-47da-b899-153397b12309

