### PR TITLE
Fix hooks render error

### DIFF
--- a/grommet-leaflet-core/src/layers/Marker.jsx
+++ b/grommet-leaflet-core/src/layers/Marker.jsx
@@ -1,47 +1,18 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import ReactDOMServer from 'react-dom/server';
+import { ThemeContext } from 'styled-components';
 import {
   createElementObject,
   createPathComponent,
   extendContext,
 } from '@react-leaflet/core';
+import { Popup as LeafletPopup } from 'react-leaflet';
 import L from 'leaflet';
-import { ThemeContext } from 'grommet';
 import { Pin, Popup } from '.';
 
-const createGrommetMarker = (
-  { position, icon: iconProp, popup: popupProp, ...rest },
-  context,
-) => {
-  const theme = React.useContext(ThemeContext);
-
-  const icon = L.divIcon({
-    // 'grommet-marker' class prevents leaflet default divIcon styles
-    className: 'grommet-marker',
-    html: ReactDOMServer.renderToString(
-      <ThemeContext.Provider value={theme}>
-        {iconProp || <Pin />}
-      </ThemeContext.Provider>,
-    ),
-  });
-
-  const kind = iconProp?.props?.kind;
+const createGrommetMarker = ({ position, icon, kind, ...rest }, context) => {
   const options = { icon, kind, ...rest };
   const marker = new L.Marker(position, options);
-
-  if (popupProp) {
-    const popup = marker.bindPopup(
-      ReactDOMServer.renderToString(
-        <ThemeContext.Provider value={theme}>
-          <Popup>{popupProp}</Popup>
-        </ThemeContext.Provider>,
-      ),
-    );
-
-    marker.on('click', () => {
-      popup.openPopup();
-    });
-  }
 
   return createElementObject(
     marker,
@@ -55,6 +26,35 @@ const updateGrommetMarker = (instance, props, prevProps) => {
   }
 };
 
-const Marker = createPathComponent(createGrommetMarker, updateGrommetMarker);
+const LeafletMarker = createPathComponent(
+  createGrommetMarker,
+  updateGrommetMarker,
+);
 
+const Marker = ({ children, icon, ...rest }) => {
+  const theme = useContext(ThemeContext);
+  const kind = icon?.props?.kind;
+
+  return (
+    <LeafletMarker
+      icon={L.divIcon({
+        // 'grommet-marker' class prevents leaflet default divIcon styles
+        className: 'grommet-marker',
+        html: ReactDOMServer.renderToString(
+          <ThemeContext.Provider value={theme}>
+            {icon || <Pin />}
+          </ThemeContext.Provider>,
+        ),
+      })}
+      kind={kind}
+      {...rest}
+    >
+      {children && (
+        <LeafletPopup>
+          <Popup>{children}</Popup>
+        </LeafletPopup>
+      )}
+    </LeafletMarker>
+  );
+};
 export { Marker };

--- a/grommet-leaflet-core/src/layers/MarkerCluster.jsx
+++ b/grommet-leaflet-core/src/layers/MarkerCluster.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import {
   createElementObject,
@@ -10,46 +10,10 @@ import 'leaflet.markercluster';
 import ReactDOMServer from 'react-dom/server';
 import { Cluster, Popup } from '.';
 
-const createMarkerClusterGroup = (
-  { icon: iconProp, popup: popupProp, ...rest },
-  context,
-) => {
-  const theme = React.useContext(ThemeContext);
-
+const createMarkerClusterGroup = ({ ...rest }, context) => {
   const markerClusterGroup = new L.MarkerClusterGroup({
     showCoverageOnHover: false,
     zoomToBoundsOnClick: false,
-    iconCreateFunction: cluster => {
-      if (popupProp) {
-        const popup = cluster.bindPopup(
-          ReactDOMServer.renderToString(
-            <ThemeContext.Provider value={theme}>
-              <Popup>{popupProp(cluster)}</Popup>
-            </ThemeContext.Provider>,
-          ),
-        );
-
-        cluster.on('click', () => {
-          popup.openPopup();
-        });
-      }
-
-      return L.divIcon({
-        // 'grommet-cluster-group' class prevents leaflet default divIcon styles
-        className: 'grommet-cluster-group',
-        html: ReactDOMServer.renderToString(
-          <ThemeContext.Provider value={theme}>
-            {iconProp ? (
-              React.cloneElement(iconProp(cluster), {
-                cluster,
-              })
-            ) : (
-              <Cluster cluster={cluster} />
-            )}
-          </ThemeContext.Provider>,
-        ),
-      });
-    },
     ...rest,
   });
   return createElementObject(
@@ -67,9 +31,49 @@ const updateMarkerClusterGroup = (instance, props, prevProps) => {
   }
 };
 
-const MarkerCluster = createPathComponent(
+const LeafletMarkerCluster = createPathComponent(
   createMarkerClusterGroup,
   updateMarkerClusterGroup,
 );
+
+const MarkerCluster = ({ icon: iconProp, popup: popupProp, ...rest }) => {
+  const theme = useContext(ThemeContext);
+  return (
+    <LeafletMarkerCluster
+      iconCreateFunction={cluster => {
+        if (popupProp) {
+          const popup = cluster.bindPopup(
+            ReactDOMServer.renderToString(
+              <ThemeContext.Provider value={theme}>
+                <Popup>{popupProp(cluster)}</Popup>
+              </ThemeContext.Provider>,
+            ),
+          );
+
+          cluster.on('click', () => {
+            popup.openPopup();
+          });
+        }
+
+        return L.divIcon({
+          // 'grommet-cluster-group' class prevents leaflet default divIcon styles
+          className: 'grommet-cluster-group',
+          html: ReactDOMServer.renderToString(
+            <ThemeContext.Provider value={theme}>
+              {iconProp ? (
+                React.cloneElement(iconProp(cluster), {
+                  cluster,
+                })
+              ) : (
+                <Cluster cluster={cluster} />
+              )}
+            </ThemeContext.Provider>,
+          ),
+        });
+      }}
+      {...rest}
+    />
+  );
+};
 
 export { MarkerCluster };

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,9 +760,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001517:
-  version "1.0.30001518"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz#b3ca93904cb4699c01218246c4d77a71dbe97150"
-  integrity sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==
+  version "1.0.30001519"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz#3e7b8b8a7077e78b0eb054d69e6edf5c7df35601"
+  integrity sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -895,9 +895,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 electron-to-chromium@^1.4.477:
-  version "1.4.477"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.477.tgz#05669aa6f161ee9076a6805457e9bd9fe6d0dfd1"
-  integrity sha512-shUVy6Eawp33dFBFIoYbIwLHrX0IZ857AlH9ug2o4rvbWmpaCUdBpQ5Zw39HRrfzAFm4APJE9V+E2A/WB0YqJw==
+  version "1.4.485"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.485.tgz#fde3ee9ee8112a3414c0dfa545385ad08ec43408"
+  integrity sha512-1ndQ5IBNEnFirPwvyud69GHL+31FkE09gH/CJ6m3KCbkx3i0EVOrjwz4UNxRmN9H8OVHbC6vMRZGN1yCvjSs9w==
 
 emoji-regex@^9.2.2:
   version "9.2.2"
@@ -1037,9 +1037,9 @@ eslint-config-airbnb@^19.0.4:
     object.entries "^1.1.5"
 
 eslint-config-prettier@^8.5.0:
-  version "8.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.9.0.tgz#094b6254b2804b0544f7cee535f802b6d29ee10b"
-  integrity sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz#3a06a662130807e2502fc3ff8b4143d8a0658e11"
+  integrity sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==
 
 eslint-import-resolver-node@^0.3.7:
   version "0.3.7"
@@ -1789,9 +1789,9 @@ magic-string@^0.27.0:
     "@jridgewell/sourcemap-codec" "^1.4.13"
 
 markdown-to-jsx@^7.2.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.2.1.tgz#87061fd3176ad926ef3d99493e5c57f6335e0c51"
-  integrity sha512-9HrdzBAo0+sFz9ZYAGT5fB8ilzTW+q6lPocRxrIesMO+aB40V9MgFfbfMXxlGjf22OpRy+IXlvVaQenicdpgbg==
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.3.1.tgz#11bfd95573d3ada43c149d03e8cf81c8a8f7773d"
+  integrity sha512-UQm7q0Pj/OjNoVbSJWb81qQFFZlZluOdn5fAb/GP5ku9LiBvCDqu8laEDsTFXweYQeLxnTexNcjRZdyOW+souw==
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -2131,9 +2131,9 @@ rimraf@^3.0.2:
     glob "^7.1.3"
 
 rollup@^3.25.2:
-  version "3.27.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.27.0.tgz#15bd07e2e1cbfa9255bf6a3f04a432621c2f3550"
-  integrity sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==
+  version "3.27.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.27.2.tgz#59adc973504408289be89e5978e938ce852c9520"
+  integrity sha512-YGwmHf7h2oUHkVBT248x0yt6vZkYQ3/rvE5iQuVBh3WO8GcJ6BNeOkpoX1yMHIiBm18EMLjBPIoUDkhgnyxGOQ==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -2401,9 +2401,9 @@ uri-js@^4.2.2:
     punycode "^2.1.0"
 
 vite@^4.1.4:
-  version "4.4.7"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.4.7.tgz#71b8a37abaf8d50561aca084dbb77fa342824154"
-  integrity sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.4.8.tgz#31e4a438f8748695c68bd57ffd262ba93540fdf7"
+  integrity sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==
   dependencies:
     esbuild "^0.18.10"
     postcss "^8.4.26"


### PR DESCRIPTION
This fixes an error where the order of hooks on each render was changing. This is because we had a `useContext` inside a nested function (createGrommetMarker and createMarkerClusterGroup). To fix this, I have wrapped each of these functions in a React component. By importing `useContext` at the top-level React component, the error is removed.

Additionally, changed the pattern of `popup` on individual Marker to use children the way leaflet wants. This works better with the new component approach because the instance of the marker is not yet available.

Otherwise, the API surface of the components remains untouched.

To test, go to "servers" page in dev mode and open your console. As you resize your window, there should be no error from "order of hooks has changed".