### PR TITLE
Suppress useLayoutEffect warning

### DIFF
--- a/grommet-leaflet-core/src/index.js
+++ b/grommet-leaflet-core/src/index.js
@@ -1,2 +1,22 @@
+/* 
+Ignore the useLayoutEffect warning from react. This warning should be removed in 
+the next react release and we can remove this code.
+React PR to remove error: https://github.com/facebook/react/pull/26395.
+This solution came from a Stack overflow suggestion:
+https://stackoverflow.com/questions/64158705/ignore-certain-console-errors-warnings-in-react
+*/
+window.console = console;
+
+const consoleError = console.error;
+const SUPPRESSED_WARNINGS = [
+  'useLayoutEffect does nothing on the server, because its effect cannot',
+];
+
+console.error = function filterWarnings(msg, ...args) {
+  if (!SUPPRESSED_WARNINGS.some(entry => msg.includes(entry))) {
+    consoleError(msg, ...args);
+  }
+};
+
 export * from './layers';
 export * from './utils';


### PR DESCRIPTION
This PR suppresses the `useLayoutEffect` warning. This warning will be removed in the next version of React. For now this code is a temporary solution until the next version of react is released. See https://github.com/facebook/react/pull/26395.

I also attempted a different solution where instead of suppressing the warning I replaced `ReactDOMServer.renderToString` with a method that uses `createRoot` and `flushSync` (solution can be found here: https://stackoverflow.com/questions/58181405/pass-a-react-component-to-leaflet-popup). This did fix the useLayoutEffect errors but I thought that the [performance issues with flushSync](https://react.dev/reference/react-dom/flushSync) were not worth it and we would be better off suppressing the warning.

Closes https://github.com/grommet/grommet-leaflet/issues/37