### PR TITLE
Fix cluster sizing

### DIFF
--- a/grommet-leaflet/src/themes/base.js
+++ b/grommet-leaflet/src/themes/base.js
@@ -1,30 +1,41 @@
-const markerKinds = {
-  default: {
-    container: {
-      // any box props
-      align: 'center',
-      justify: 'center',
-      background: 'background-front',
-      border: {
-        color: 'border',
-        size: 'small',
-      },
-      elevation: 'medium',
-      flex: false,
-      round: 'full',
-      height: { min: '25px', max: '25px' },
-      width: { min: '25px', max: '25px' },
-    },
-    // icon: undefined,
-  },
-};
-
 const base = {
   pin: {
-    ...markerKinds,
+    default: {
+      container: {
+        // any box props
+        align: 'center',
+        justify: 'center',
+        background: 'background-front',
+        border: {
+          color: 'border',
+          size: 'small',
+        },
+        elevation: 'medium',
+        flex: false,
+        round: 'full',
+        height: { min: '25px', max: '25px' },
+        width: { min: '25px', max: '25px' },
+      },
+      // icon: undefined,
+    },
   },
   cluster: {
-    ...markerKinds,
+    default: {
+      container: {
+        // any box props
+        align: 'center',
+        justify: 'center',
+        background: 'background-front',
+        border: {
+          color: 'border',
+          size: 'small',
+        },
+        elevation: 'medium',
+        flex: false,
+        round: 'full',
+      },
+      // icon: undefined,
+    },
     size: {
       small: {
         container: {

--- a/grommet-leaflet/src/themes/base.js
+++ b/grommet-leaflet/src/themes/base.js
@@ -1,41 +1,39 @@
-const base = {
-  pin: {
-    default: {
-      container: {
-        // any box props
-        align: 'center',
-        justify: 'center',
-        background: 'background-front',
-        border: {
-          color: 'border',
-          size: 'small',
-        },
-        elevation: 'medium',
-        flex: false,
-        round: 'full',
-        height: { min: '25px', max: '25px' },
-        width: { min: '25px', max: '25px' },
+import { deepMerge } from 'grommet/utils';
+
+const defaultKinds = {
+  default: {
+    container: {
+      // any box props
+      align: 'center',
+      justify: 'center',
+      background: 'background-front',
+      border: {
+        color: 'border',
+        size: 'small',
       },
-      // icon: undefined,
+      elevation: 'medium',
+      flex: false,
+      round: 'full',
+    },
+    // icon: undefined,
+  },
+};
+
+const markerKinds = deepMerge(defaultKinds, {
+  default: {
+    container: {
+      height: { min: '25px', max: '25px' },
+      width: { min: '25px', max: '25px' },
     },
   },
+});
+
+const base = {
+  pin: {
+    ...markerKinds,
+  },
   cluster: {
-    default: {
-      container: {
-        // any box props
-        align: 'center',
-        justify: 'center',
-        background: 'background-front',
-        border: {
-          color: 'border',
-          size: 'small',
-        },
-        elevation: 'medium',
-        flex: false,
-        round: 'full',
-      },
-      // icon: undefined,
-    },
+    ...defaultKinds,
     size: {
       small: {
         container: {


### PR DESCRIPTION
The theme props defined for the kind of cluster should take precedence over the theme props defined for the size of cluster. I removed the height and width from the default kind so that those could be driven from the size.