### PR TITLE
Ensure markers have unique keys

### DIFF
--- a/demo-app/src/pages/servers/index.jsx
+++ b/demo-app/src/pages/servers/index.jsx
@@ -63,7 +63,13 @@ const Servers = () => {
 export default Servers;
 
 const DataView = () => (
-  <Data data={data.servers.items}>
+  <Data
+    data={data.servers.items}
+    properties={{
+      'hardware.health.summary': { label: 'Status' },
+      'host.osName': { label: 'Host OS name' },
+    }}
+  >
     <Toolbar>
       <DataSearch responsive />
       <DataFilters layer />

--- a/grommet-leaflet/package.json
+++ b/grommet-leaflet/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "leaflet": "^1.9.3",
     "leaflet.markercluster": "^1.5.3",
-    "react-leaflet": "^4.2.1"
+    "react-leaflet": "^4.2.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "prop-types": "^15.8.1"

--- a/grommet-leaflet/src/layers/Marker.jsx
+++ b/grommet-leaflet/src/layers/Marker.jsx
@@ -1,35 +1,10 @@
 import React, { useContext } from 'react';
 import ReactDOMServer from 'react-dom/server';
+import { v4 as uuidv4 } from 'uuid';
 import { ThemeContext } from 'styled-components';
-import {
-  createElementObject,
-  createPathComponent,
-  extendContext,
-} from '@react-leaflet/core';
-import { Popup as LeafletPopup } from 'react-leaflet';
+import { Popup as LeafletPopup, Marker as LeafletMarker } from 'react-leaflet';
 import L from 'leaflet';
 import { Pin, Popup } from '.';
-
-const createGrommetMarker = ({ position, icon, kind, ...rest }, context) => {
-  const options = { icon, kind, ...rest };
-  const marker = new L.Marker(position, options);
-
-  return createElementObject(
-    marker,
-    extendContext(context, { overlayContainer: marker }),
-  );
-};
-
-const updateGrommetMarker = (instance, props, prevProps) => {
-  if (props.position !== prevProps.position) {
-    instance.setLatLng(props.position);
-  }
-};
-
-const LeafletMarker = createPathComponent(
-  createGrommetMarker,
-  updateGrommetMarker,
-);
 
 const Marker = ({ children, icon, ...rest }) => {
   const theme = useContext(ThemeContext);
@@ -37,6 +12,12 @@ const Marker = ({ children, icon, ...rest }) => {
 
   return (
     <LeafletMarker
+      // https://react-leaflet.js.org/docs/start-introduction/#limitations
+      // The components exposed are abstractions for Leaflet layers, not DOM elements.
+      // Some of them have properties that can be updated directly by calling the setters exposed by Leaflet while others
+      // should be completely replaced, by setting an unique value on their key property so they are properly
+      // handled by React's algorithm.
+      key={uuidv4()}
       icon={L.divIcon({
         // 'grommet-marker' class prevents leaflet default divIcon styles
         className: 'grommet-marker',
@@ -57,4 +38,5 @@ const Marker = ({ children, icon, ...rest }) => {
     </LeafletMarker>
   );
 };
+
 export { Marker };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,6 +2400,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 vite@^4.1.4:
   version "4.4.8"
   resolved "https://registry.yarnpkg.com/vite/-/vite-4.4.8.tgz#31e4a438f8748695c68bd57ffd262ba93540fdf7"


### PR DESCRIPTION
Uses `uuid` to ensure each marker has a unique identifier, applying this internally on Marker. This is necessary so that as children of cluster change, the cluster icon properly updates. Additionally, leveraging `Marker` from react-leaflet as opposed to rolling our own because [their update function](https://github.com/PaulLeCam/react-leaflet/blob/master/packages/react-leaflet/src/Marker.tsx#L27) includes more checks to make sure the Marker is up to date, for example it include a setIcon function. Optionally, we could roll our own and copy and paste from theirs but it felt reasonable to just leverage theirs.

I believe the reason passing something more conventional like `index` or `server.id` onto an individual Marker is rooted in a limitation of react-leaflet which is documented our their site: https://react-leaflet.js.org/docs/start-introduction/#limitations

Through my searching, others suggested a unique key approach in similar-ish problems (some of the other solutions suggested in these threads did not work):
- https://github.com/yuzhva/react-leaflet-markercluster/issues/100#issuecomment-597668784
- https://github.com/yuzhva/react-leaflet-markercluster/issues/149#issuecomment-854920761
- I had also found a thread of folks specifically using uuid, but can't seem to find it at the moment.

Note:
- One thing that's a little weird here is that Marker is applying `uuid` key internally. However, the caller still has to apply `key` on their side otherwise React will complain, but ultimately their key isn't being used for anything. I think this is okay because `key` from the caller doesn't override the internal marker one, but the pattern is just a little weird.

Demo with Data + filtering.

https://github.com/grommet/grommet-leaflet/assets/12522275/9a13ce11-112d-45c1-8ea2-5c8ad6ddaf65


Closes #21