### PR TITLE
Allow caller to specify container and leaflet props if desired

### DIFF
--- a/demo-app/src/pages/servers/ServersMap.jsx
+++ b/demo-app/src/pages/servers/ServersMap.jsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Box } from 'grommet';
-import { Grommet } from 'grommet-icons';
+import React, { useRef } from 'react';
+import { Anchor, Box, Text } from 'grommet';
 import {
   Cluster,
   Controls,
@@ -10,61 +9,58 @@ import {
   Pin,
 } from 'grommet-leaflet';
 import { hpeLeaflet } from '../../themes';
-import { getClusterSize, getClusterStatus, userLocation } from '../../utils';
+import { getClusterSize, getClusterStatus } from '../../utils';
 import { ServersClusterPopup } from './ServersClusterPopup';
+import { TextEmphasis } from '../../components';
 import data from './data/servers.json';
 
 export const ServersMap = () => {
-  const [geolocation, setGeolocation] = useState();
-  const servers = data.servers.items;
-
   const containerRef = useRef();
   const mapContainerRef = useRef();
 
-  // TO DO -- should this still be the default center?
-  // get the user's location
-  useEffect(() => {
-    userLocation().then(location => {
-      setGeolocation(location);
-    });
-  }, []);
-
   return (
     <Box ref={containerRef} flex background="background-contrast">
-      {geolocation && (
-        <Map
-          id="map"
-          ref={mapContainerRef}
-          center={geolocation}
-          zoom={6}
-          zoomControl={false}
-          theme={hpeLeaflet}
+      <Map ref={mapContainerRef} theme={hpeLeaflet}>
+        <Controls locations={data.servers.items.map(item => item.location)} />
+        <MarkerCluster
+          popup={cluster => <ServersClusterPopup cluster={cluster} />}
+          icon={cluster => {
+            const kind = getClusterStatus(cluster.getAllChildMarkers());
+            const size = getClusterSize(cluster);
+            return <Cluster kind={kind} size={size} />;
+          }}
+          chunkedLoading
         >
-          <Controls locations={servers.map(server => server.location)} />
-          <Marker position={geolocation} icon={<Grommet />} />
-          <MarkerCluster
-            popup={cluster => <ServersClusterPopup cluster={cluster} />}
-            icon={cluster => {
-              const kind = getClusterStatus(cluster.getAllChildMarkers());
-              const size = getClusterSize(cluster);
-              return <Cluster kind={kind} size={size} />;
-            }}
-          >
-            {servers.map((server, index) => {
-              let status = server?.hardware?.health?.summary?.toLowerCase();
-              if (status === 'ok') status = 'good';
+          {data.servers.items.map((server, index) => {
+            let status = server?.hardware?.health?.summary?.toLowerCase();
+            if (status === 'ok') status = 'good';
 
-              return (
-                <Marker
-                  key={index}
-                  position={server?.location}
-                  icon={<Pin kind={status} />}
-                />
-              );
-            })}
-          </MarkerCluster>
-        </Map>
-      )}
+            return (
+              <Marker
+                key={index}
+                position={server?.location}
+                icon={<Pin kind={status} />}
+                popup={() => (
+                  <MarkerPopup
+                    name={server.displayName}
+                    model={server.hardware?.model}
+                  />
+                )}
+              />
+            );
+          })}
+        </MarkerCluster>
+      </Map>
     </Box>
   );
 };
+
+const MarkerPopup = ({ name, model }) => (
+  <Box gap="xsmall" pad={{ right: 'xsmall' }}>
+    <Box>
+      <TextEmphasis>{name}</TextEmphasis>
+      <Text size="small">{model}</Text>
+    </Box>
+    <Anchor label="View details" size="small" />
+  </Box>
+);

--- a/grommet-leaflet/src/grommet-leaflet-reset.css
+++ b/grommet-leaflet/src/grommet-leaflet-reset.css
@@ -37,3 +37,6 @@
 .leaflet-bottom {
     z-index: 91;
 }
+.leaflet-container a {
+    color: inherit;
+}

--- a/grommet-leaflet/src/layers/Cluster.jsx
+++ b/grommet-leaflet/src/layers/Cluster.jsx
@@ -41,7 +41,7 @@ const Cluster = ({ cluster, kind = 'default', size = 'medium', ...rest }) => {
 };
 
 Cluster.propTypes = {
-  cluster: PropTypes.object.isRequired,
+  cluster: PropTypes.object,
   kind: PropTypes.string,
 };
 

--- a/grommet-leaflet/src/layers/Marker.jsx
+++ b/grommet-leaflet/src/layers/Marker.jsx
@@ -9,13 +9,16 @@ const Marker = ({ children, icon, popup: popupProp, ...rest }) => {
   const theme = useContext(ThemeContext);
   const kind = icon?.props?.kind;
 
-  const popup = (
-    <LeafletPopup {...popupProp.leafletProps}>
-      <Popup {...popupProp.boxProps}>
-        {typeof popupProp === 'function' ? popupProp() : popupProp.render()}
-      </Popup>
-    </LeafletPopup>
-  );
+  let popup;
+  if (popupProp) {
+    popup = (
+      <LeafletPopup {...popupProp.leafletProps}>
+        <Popup {...popupProp.boxProps}>
+          {typeof popupProp === 'function' ? popupProp() : popupProp.render()}
+        </Popup>
+      </LeafletPopup>
+    );
+  }
 
   return (
     <LeafletMarker
@@ -31,7 +34,7 @@ const Marker = ({ children, icon, popup: popupProp, ...rest }) => {
       kind={kind}
       {...rest}
     >
-      {popupProp ? popup : undefined}
+      {popup}
     </LeafletMarker>
   );
 };

--- a/grommet-leaflet/src/layers/Marker.jsx
+++ b/grommet-leaflet/src/layers/Marker.jsx
@@ -1,39 +1,21 @@
 import React, { useContext } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { ThemeContext } from 'styled-components';
-import {
-  createElementObject,
-  createPathComponent,
-  extendContext,
-} from '@react-leaflet/core';
-import { Popup as LeafletPopup } from 'react-leaflet';
+import { Marker as LeafletMarker, Popup as LeafletPopup } from 'react-leaflet';
 import L from 'leaflet';
 import { Pin, Popup } from '.';
 
-const createGrommetMarker = ({ position, icon, kind, ...rest }, context) => {
-  const options = { icon, kind, ...rest };
-  const marker = new L.Marker(position, options);
-
-  return createElementObject(
-    marker,
-    extendContext(context, { overlayContainer: marker }),
-  );
-};
-
-const updateGrommetMarker = (instance, props, prevProps) => {
-  if (props.position !== prevProps.position) {
-    instance.setLatLng(props.position);
-  }
-};
-
-const LeafletMarker = createPathComponent(
-  createGrommetMarker,
-  updateGrommetMarker,
-);
-
-const Marker = ({ children, icon, ...rest }) => {
+const Marker = ({ children, icon, popup: popupProp, ...rest }) => {
   const theme = useContext(ThemeContext);
   const kind = icon?.props?.kind;
+
+  const popup = (
+    <LeafletPopup {...popupProp.leafletProps}>
+      <Popup {...popupProp.boxProps}>
+        {typeof popupProp === 'function' ? popupProp() : popupProp.render()}
+      </Popup>
+    </LeafletPopup>
+  );
 
   return (
     <LeafletMarker
@@ -49,11 +31,7 @@ const Marker = ({ children, icon, ...rest }) => {
       kind={kind}
       {...rest}
     >
-      {children && (
-        <LeafletPopup>
-          <Popup>{children}</Popup>
-        </LeafletPopup>
-      )}
+      {popupProp ? popup : undefined}
     </LeafletMarker>
   );
 };

--- a/grommet-leaflet/src/layers/MarkerCluster.jsx
+++ b/grommet-leaflet/src/layers/MarkerCluster.jsx
@@ -22,19 +22,7 @@ const createMarkerClusterGroup = ({ ...rest }, context) => {
   );
 };
 
-const updateMarkerClusterGroup = (instance, props, prevProps) => {
-  if (props.children !== prevProps.children) {
-    // TO DO revisit proper approach to update marker cluster group.
-    // https://github.com/grommet/grommet-leaflet/issues/21
-    // instance.clearLayers();
-    // instance.addLayers(props.children);
-  }
-};
-
-const LeafletMarkerCluster = createPathComponent(
-  createMarkerClusterGroup,
-  updateMarkerClusterGroup,
-);
+const LeafletMarkerCluster = createPathComponent(createMarkerClusterGroup);
 
 const MarkerCluster = ({ icon: iconProp, popup: popupProp, ...rest }) => {
   const theme = useContext(ThemeContext);
@@ -45,9 +33,14 @@ const MarkerCluster = ({ icon: iconProp, popup: popupProp, ...rest }) => {
           const popup = cluster.bindPopup(
             ReactDOMServer.renderToString(
               <ThemeContext.Provider value={theme}>
-                <Popup>{popupProp(cluster)}</Popup>
+                <Popup {...popupProp.boxProps}>
+                  {typeof popupProp === 'function'
+                    ? popupProp(cluster)
+                    : popupProp.render(cluster)}
+                </Popup>
               </ThemeContext.Provider>,
             ),
+            { ...popupProp.leafletProps },
           );
 
           cluster.on('click', () => {


### PR DESCRIPTION
This PR aligns the API structure for Marker and MarkerCluster `popup` prop. The 80% case is the caller will rely on the theme's popup container properties and Leaflet's default popup properties. The 20% (if that) case if the caller will want to override the popup container properties or leaflet properties.

To gear the API surface for the 80% case, the caller can leverage a function:

```
// where cluster is used to determine content in the popup content
<MarkerCluster popup={(cluster) => <MyClusterPopupContent cluster={cluster} />} />

<Marker popup={() => <MyMarkerPopupContent />
```

To support the 20% case, the caller can also pass the following structure to `popup` on Marker or MarkerCluster:

```
popup={{
   render: cluster => <MyClusterPopupContent cluster={cluster} />,
   boxProps: {
      // any box props to affect the popup container
   },
   leafletProps: {
      // any leaflet popup props
  }
}}
```

Notes:
- the leaflet css file needed to be adjusted so an Anchor inside a popup wasn't getting leaflet defined color. We should audit any other styles from leaflet css to determine additional overrides we might need.

Closes #45 