### PR TITLE
Fixed issue where default Marker styling was not coming through from the theme

### DIFF
--- a/grommet-leaflet/src/layers/Map/Map.jsx
+++ b/grommet-leaflet/src/layers/Map/Map.jsx
@@ -9,7 +9,11 @@ import { TileLayer } from '../TileLayer';
 const StyledMapContainer = styled(MapContainer)`
   ${({ theme }) => {
     return `
-      font-family: ${theme.global.font.family};
+      ${
+        theme?.global?.font?.family
+          ? `font-family: ${theme.global.font.family};`
+          : ''
+      }
       height: 100%;
     `;
   }}

--- a/grommet-leaflet/src/layers/Marker/Marker.jsx
+++ b/grommet-leaflet/src/layers/Marker/Marker.jsx
@@ -20,10 +20,11 @@ const Marker = ({ icon, popup: popupProp, ...rest }) => {
   return (
     <LeafletMarker
       // https://react-leaflet.js.org/docs/start-introduction/#limitations
-      // The components exposed are abstractions for Leaflet layers, not DOM elements.
-      // Some of them have properties that can be updated directly by calling the setters exposed by Leaflet while others
-      // should be completely replaced, by setting an unique value on their key property so they are properly
-      // handled by React's algorithm.
+      // The components exposed are abstractions for Leaflet layers, not DOM
+      // elements. Some of them have properties that can be updated directly
+      // by calling the setters exposed by Leaflet while others should be
+      // completely replaced, by setting an unique value on their key property
+      // so they are properly handled by React's algorithm.
       key={uuidv4()}
       icon={L.divIcon({
         // 'grommet-marker' class prevents leaflet default divIcon styles

--- a/grommet-leaflet/src/layers/Pin/Pin.jsx
+++ b/grommet-leaflet/src/layers/Pin/Pin.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { Box, ThemeContext } from 'grommet';
+import styled, { ThemeContext } from 'styled-components';
+import { Box } from 'grommet';
 import { normalizeTheme } from '../../utils';
 
 const StyledBox = styled(Box)`


### PR DESCRIPTION
Closes https://github.com/grommet/hpe-design-system/issues/3965

- Fixed issue where default Marker styling was not coming through from the theme by using ThemeContext from Styled-Components instead of Grommet.
- Makes Map styling more defensive if theme value is undefined.