### PR TITLE
Add deepMerge util function

### DIFF
--- a/grommet-leaflet/src/layers/Map/Map.jsx
+++ b/grommet-leaflet/src/layers/Map/Map.jsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { MapContainer, AttributionControl } from 'react-leaflet';
 import styled, { ThemeContext } from 'styled-components';
-import { deepMerge } from 'grommet/utils';
+import { deepMerge } from 'grommet';
 import { base } from '../../themes';
 import { TileLayer } from '../TileLayer';
 

--- a/grommet-leaflet/src/layers/Map/Map.jsx
+++ b/grommet-leaflet/src/layers/Map/Map.jsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { MapContainer, AttributionControl } from 'react-leaflet';
 import styled, { ThemeContext } from 'styled-components';
-import { deepMerge } from 'grommet';
+import { deepMerge } from '../../utils';
 import { base } from '../../themes';
 import { TileLayer } from '../TileLayer';
 

--- a/grommet-leaflet/src/themes/base.js
+++ b/grommet-leaflet/src/themes/base.js
@@ -1,4 +1,4 @@
-import { deepMerge } from 'grommet/utils';
+import { deepMerge } from 'grommet';
 
 const defaultKinds = {
   default: {

--- a/grommet-leaflet/src/themes/base.js
+++ b/grommet-leaflet/src/themes/base.js
@@ -1,4 +1,4 @@
-import { deepMerge } from 'grommet';
+import { deepMerge } from '../utils';
 
 const defaultKinds = {
   default: {

--- a/grommet-leaflet/src/utils.js
+++ b/grommet-leaflet/src/utils.js
@@ -1,4 +1,29 @@
-import { deepMerge } from 'grommet';
+export const isObject = item =>
+  item && typeof item === 'object' && !Array.isArray(item);
+
+export const deepMerge = (target, ...sources) => {
+  if (!sources.length) {
+    return target;
+  }
+  // making sure to not change target (immutable)
+  const output = { ...target };
+  sources.forEach(source => {
+    if (isObject(source)) {
+      Object.keys(source).forEach(key => {
+        if (isObject(source[key])) {
+          if (!output[key]) {
+            output[key] = { ...source[key] };
+          } else {
+            output[key] = deepMerge(output[key], source[key]);
+          }
+        } else {
+          output[key] = source[key];
+        }
+      });
+    }
+  });
+  return output;
+};
 
 export const normalizeTheme = themeObjects => {
   let result = {};

--- a/grommet-leaflet/src/utils.js
+++ b/grommet-leaflet/src/utils.js
@@ -1,4 +1,4 @@
-import { deepMerge } from 'grommet/utils';
+import { deepMerge } from 'grommet';
 
 export const normalizeTheme = themeObjects => {
   let result = {};

--- a/grommet-leaflet/vite.config.js
+++ b/grommet-leaflet/vite.config.js
@@ -14,13 +14,14 @@ export default defineConfig({
     },
     rollupOptions: {
       // externalize deps that shouldn't be bundled with library
-      external: ['react', 'styled-components', 'prop-types', /node_modules/],
+      external: ['react', 'react-dom', 'styled-components', 'grommet'],
       output: {
         // global variables to use in the UMD build for externalized deps
         globals: {
           react: 'React',
           'styled-components': 'styled',
-          'prop-types': 'PropTypes',
+          'react-dom': 'ReactDOM',
+          grommet: 'grommet',
         },
       },
     },

--- a/grommet-leaflet/vite.config.js
+++ b/grommet-leaflet/vite.config.js
@@ -14,13 +14,7 @@ export default defineConfig({
     },
     rollupOptions: {
       // externalize deps that shouldn't be bundled with library
-      external: [
-        'react',
-        'react-dom',
-        'styled-components',
-        'grommet',
-        'grommet/utils',
-      ],
+      external: ['react', 'react-dom', 'styled-components', 'grommet'],
       output: {
         // global variables to use in the UMD build for externalized deps
         globals: {
@@ -28,7 +22,6 @@ export default defineConfig({
           'styled-components': 'styled',
           'react-dom': 'ReactDOM',
           grommet: 'grommet',
-          'grommet/utils': 'grommet',
         },
       },
     },

--- a/grommet-leaflet/vite.config.js
+++ b/grommet-leaflet/vite.config.js
@@ -14,7 +14,13 @@ export default defineConfig({
     },
     rollupOptions: {
       // externalize deps that shouldn't be bundled with library
-      external: ['react', 'react-dom', 'styled-components', 'grommet'],
+      external: [
+        'react',
+        'react-dom',
+        'styled-components',
+        'grommet',
+        'grommet/utils',
+      ],
       output: {
         // global variables to use in the UMD build for externalized deps
         globals: {
@@ -22,6 +28,7 @@ export default defineConfig({
           'styled-components': 'styled',
           'react-dom': 'ReactDOM',
           grommet: 'grommet',
+          'grommet/utils': 'grommet',
         },
       },
     },


### PR DESCRIPTION
importing `deepMerge` from `grommet/utils` becomes problematic when bundling as the consuming package is unable to resolve if consuming the cjs bundle. Additionally, deepMerge isn't part of Grommet's documented API and could [validly] break if the directory structure changed for any reason, so shouldn't be relied on. Instead, creating deepMerge function local to this project.