### PR TITLE
Add SPDX license header tooling for OSRB compliance

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,48 @@
+name: License Compliance
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: license-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  license-check:
+    name: SPDX header check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.4.1'
+      - name: Verify SPDX license headers (changed files only)
+        run: |
+          set -e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RANGE="${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            # Guard against the all-zero SHA GitHub sends for
+            # branch-creation pushes (no prior commit to diff against).
+            if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+              echo "No base commit to diff against; skipping check."
+              exit 0
+            fi
+            RANGE="$BASE...${{ github.sha }}"
+          fi
+          FILES="$(git diff --name-only "$RANGE" -- grommet-leaflet/src grommet-leaflet/tools demo-app/src demo-typescript/src tools)"
+          if [ -n "$FILES" ]; then
+            mapfile -t FILE_ARR <<< "$FILES"
+            node tools/license-header.js --check "${FILE_ARR[@]}"
+          else
+            echo "No relevant files changed."
+          fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+yarn license-staged

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+
+SPDX-License-Identifier: ISC

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint-fix": "eslint . --ext .js --ext .jsx --fix",
     "license": "node ./tools/license-header.js",
     "license-check": "node ./tools/license-header.js --check",
-    "license-staged": "node ./tools/license-header.js --staged"
+    "license-staged": "node ./tools/license-header.js --staged",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",
@@ -35,6 +36,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "husky": "^9.1.7",
     "prettier": "^2.8.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
   ],
   "scripts": {
     "lint": "eslint . --ext .js --ext .jsx",
-    "lint-fix": "eslint . --ext .js --ext .jsx --fix"
+    "lint-fix": "eslint . --ext .js --ext .jsx --fix",
+    "license": "node ./tools/license-header.js",
+    "license-check": "node ./tools/license-header.js --check",
+    "license-staged": "node ./tools/license-header.js --staged"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.19.1",

--- a/tools/license-header.js
+++ b/tools/license-header.js
@@ -121,6 +121,9 @@ function main() {
     roots.forEach(root => collectFiles(root, files));
   }
 
+  // readdirSync order is OS/filesystem-dependent; sort for stable output.
+  files.sort();
+
   const nonCompliant = [];
   files.forEach(file => {
     const content = fs.readFileSync(file, 'utf8');

--- a/tools/license-header.js
+++ b/tools/license-header.js
@@ -15,7 +15,8 @@
  *                                           (progressive migration) and
  *                                           re-stage anything it corrects.
  *   node tools/license-header.js [paths...] Limit to the given files/dirs.
- *                                           usable with --check or --staged.
+ *                                           usable with --check (ignored when
+ *                                           --staged is set).
  */
 
 const fs = require('fs');
@@ -52,11 +53,11 @@ function isIncluded(filePath) {
 
 // This is meant for progressive migration: only touch
 // files that are staged for commit and live under a managed
-// root and are eligible for a header licence text.
+// root and are eligible for a header license text.
 function collectStagedFiles() {
   const output = execFileSync(
     'git',
-    ['diff', '--cached', '--name-only', '--diff-filter=ACM'],
+    ['diff', '--cached', '--name-only', '--diff-filter=ACMR'],
     { encoding: 'utf8' },
   );
   return output

--- a/tools/license-header.js
+++ b/tools/license-header.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: ISC
+/**
+ * License header tool (HPE Open Source Review Board compliance).
+ *
+ * Ensures every authored source file carries the canonical SPDX header below.
+ * Works on raw text, so it covers .js/.jsx/.ts/.tsx/.mjs/.cjs uniformly.
+ *
+ * Usage:
+ *   node tools/license-header.js            Insert/correct headers (fix mode).
+ *   node tools/license-header.js --check    Report non-compliant files and exit
+ *                                           non-zero. Used for CI gating.
+ *   node tools/license-header.js --staged   Fix only files staged for commit
+ *                                           (progressive migration) and
+ *                                           re-stage anything it corrects.
+ *   node tools/license-header.js [paths...] Limit to the given files/dirs.
+ *                                           usable with --check or --staged.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+// Canonical header. Edit these two lines to change it everywhere.
+const HEADER =
+  '// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP\n' +
+  '// SPDX-License-Identifier: ISC\n';
+
+const ROOTS = [
+  'grommet-leaflet/src',
+  'grommet-leaflet/tools',
+  'demo-app/src',
+  'demo-typescript/src',
+  'tools',
+];
+const EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+const EXCLUDED_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'coverage',
+  '.git',
+  '.yarn',
+  'storybook-static',
+  '__snapshots__',
+]);
+
+function isIncluded(filePath) {
+  if (filePath.endsWith('.snap')) return false;
+  return EXTENSIONS.has(path.extname(filePath));
+}
+
+// This is meant for progressive migration: only touch
+// files that are staged for commit and live under a managed
+// root and are eligible for a header licence text.
+function collectStagedFiles() {
+  const output = execFileSync(
+    'git',
+    ['diff', '--cached', '--name-only', '--diff-filter=ACM'],
+    { encoding: 'utf8' },
+  );
+  return output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .filter(file =>
+      ROOTS.some(root => file === root || file.startsWith(`${root}/`)),
+    )
+    .filter(file => isIncluded(file))
+    .filter(file => fs.existsSync(file));
+}
+
+function collectFiles(target, out) {
+  if (!fs.existsSync(target)) return;
+  const stat = fs.statSync(target);
+  if (stat.isDirectory()) {
+    fs.readdirSync(target, { withFileTypes: true }).forEach(entry => {
+      if (entry.isDirectory() && EXCLUDED_DIRS.has(entry.name)) return;
+      collectFiles(path.join(target, entry.name), out);
+    });
+  } else if (stat.isFile() && isIncluded(target)) {
+    out.push(target);
+  }
+}
+
+// Build the canonical content for a file: shebang # (if any),
+// header, then the body with any existing SPDX header lines stripped.
+function buildExpected(content) {
+  let shebang = '';
+  let body = content;
+  if (content.startsWith('#!')) {
+    const nl = content.indexOf('\n');
+    shebang = nl === -1 ? `${content}\n` : content.slice(0, nl + 1);
+    body = nl === -1 ? '' : content.slice(nl + 1);
+  }
+  const lines = body.split('\n');
+  let i = 0;
+  while (i < lines.length && /^\/\/\s*SPDX-/i.test(lines[i])) i += 1;
+  if (i > 0 && lines[i]?.trim() === '') i += 1;
+  const rest = lines.slice(i);
+  // A directive prologue ('use client' / 'use strict') must have a blank line
+  // before it when comments precede it (ESLint lines-around-directive).
+  // Keeping one here, so the tool and ESLint agree on the canonical form.
+  const needsBlank = /^\s*(['"])use [\w-]+\1;?\s*$/.test(rest[0] ?? '');
+  return `${shebang}${HEADER}${needsBlank ? '\n' : ''}${rest.join('\n')}`;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const checkOnly = args.includes('--check');
+  const stagedOnly = args.includes('--staged');
+  const targets = args.filter(arg => !arg.startsWith('--'));
+
+  let files;
+  if (stagedOnly) {
+    files = collectStagedFiles();
+  } else {
+    const roots = targets.length > 0 ? targets : ROOTS;
+    files = [];
+    roots.forEach(root => collectFiles(root, files));
+  }
+
+  const nonCompliant = [];
+  files.forEach(file => {
+    const content = fs.readFileSync(file, 'utf8');
+    const expected = buildExpected(content);
+    if (expected === content) return;
+    nonCompliant.push(file);
+    if (!checkOnly) fs.writeFileSync(file, expected);
+  });
+
+  // Re-stage anything corrected so the fix lands in the same commit.
+  if (stagedOnly && !checkOnly && nonCompliant.length > 0) {
+    execFileSync('git', ['add', '--', ...nonCompliant]);
+  }
+
+  if (checkOnly) {
+    if (nonCompliant.length > 0) {
+      console.error(
+        `License header check failed: ${nonCompliant.length} file(s) missing ` +
+          'or with an incorrect SPDX header.',
+      );
+      nonCompliant.forEach(file => console.error(`  ${file}`));
+      console.error('\nRun "yarn license" to fix the headers.');
+      process.exit(1);
+    }
+    console.log(`License header check passed (${files.length} file(s)).`);
+    return;
+  }
+
+  if (nonCompliant.length > 0) {
+    console.log(`Updated SPDX header in ${nonCompliant.length} file(s).`);
+  } else {
+    console.log(`All ${files.length} file(s) already compliant.`);
+  }
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3021,6 +3021,11 @@ https-proxy-agent@^7.0.5:
     agent-base "^7.1.2"
     debug "4"
 
+husky@^9.1.7:
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
+
 iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- `license-header.js` - dependency-free Node script that adds/validates the canonical SPDX header across source files (yarn license to fix, yarn license-check to verify). Rebuilds headers so it also corrects drift, and preserves shebangs.
- `license.yml` - CI gate running license-check on PRs and pushes to main.
- `COPYRIGHT.md` - updated to the canonical SPDX header format.
- Update scripts in `packaga.json`

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?
relates to https://github.com/grommet/hpe-design-system/issues/6360